### PR TITLE
Pull licenses file from gem location instead of ./

### DIFF
--- a/lib/bom_builder.rb
+++ b/lib/bom_builder.rb
@@ -41,7 +41,7 @@ class Bombuilder
     end
 
     @gems = []
-    licenses_file = File.read "lib/licenses.json"
+    licenses_file = File.read "#{__dir__}/licenses.json"
     @licenses_list = JSON.parse(licenses_file)
 
     if @options[:path].nil?


### PR DESCRIPTION
Allows BOMs to be generated from within another repo's directory.