### PR TITLE
Add support for JSON bom output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ cyclonedx-ruby [options]
 
     `-v, --[no-]verbose` Run verbosely
     `-p, --path path` Path to Ruby project directory
+    `-f, --format` Bom output format
     `-h, --help` Show help message
 
-**Output:** bom.xml file in project directory
+**Output:** bom.xml or bom.json file in project directory
 
 #### Example
 ```bash

--- a/cyclonedx-ruby.gemspec
+++ b/cyclonedx-ruby.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description = 'CycloneDX is a lightweight software bill-of-material (SBOM) specification designed for use in application security contexts and supply chain component analysis. This Gem generates CycloneDX BOMs from Ruby projects.'
   spec.authors     = ['Joseph Kobti', 'Steve Springett']
   spec.email       = 'josephkobti@outlook.com'
-  spec.files       = ['lib/bom_builder.rb', 'lib/bom_helpers.rb', 'lib/licenses.json']
+  spec.files       = ['lib/bom_builder.rb', 'lib/bom_helpers.rb', 'lib/licenses.json', 'lib/bom_component.rb']
   spec.homepage    = 'https://github.com/CycloneDX/cyclonedx-ruby-gem'
   spec.license     = 'Apache-2.0'
   spec.executables << 'cyclonedx-ruby'

--- a/lib/bom_builder.rb
+++ b/lib/bom_builder.rb
@@ -34,6 +34,8 @@ require_relative 'bom_helpers'
 require 'active_support/core_ext/hash'
 
 class Bombuilder
+  SUPPORTED_BOM_FORMATS = %w[xml json]
+
   def self.build(path)
     original_working_directory = Dir.pwd
     setup(path)
@@ -123,12 +125,12 @@ class Bombuilder
       abort
     end
 
-    if @options[:bom_output_format].nil? || @options[:bom_output_format] == "xml"
+    if @options[:bom_output_format].nil?
       @bom_output_format = 'xml'
-    elsif @options[:bom_output_format] == "json"
-      @bom_output_format = 'json'
+    elsif SUPPORTED_BOM_FORMATS.include?(@options[:bom_output_format])
+      @bom_output_format = @options[:bom_output_format]
     else
-      @logger.error("Unrecognized cyclonedx bom output format provided: #{@options[:bom_output_format]}")
+      @logger.error("Unrecognized cyclonedx bom output format provided. Please choose one of #{SUPPORTED_BOM_FORMATS}")
       abort
     end
 

--- a/lib/bom_component.rb
+++ b/lib/bom_component.rb
@@ -1,0 +1,45 @@
+
+class BomComponent
+  DEFAULT_TYPE = "library".freeze
+  HASH_ALG = 'SHA-256'.freeze
+
+  def initialize(gem)
+    @name = gem['name']
+    @version = gem['version']
+    @description = gem['description']
+    @hash = gem['hash']
+    @purl = gem['purl']
+    @gem = gem
+  end
+
+  def hash_val
+    component_hash = {
+      "type": DEFAULT_TYPE,
+      "name": @name,
+      "version": @version,
+      "description": @description,
+      "purl": @purl,
+      "hashes": [
+          "alg": HASH_ALG,
+          "content": @hash
+      ]
+    }
+
+    if @gem['license_id']
+      component_hash[:"licenses"] = [
+        "license": {
+          "id": @gem['license_id']
+        }
+      ]
+    elsif @gem['license_name']
+      component_hash[:"licenses"] = [
+        "license": {
+          "name": @gem['license_name']
+        }
+      ]
+    end
+
+    [component_hash]
+
+  end
+end

--- a/lib/bom_helpers.rb
+++ b/lib/bom_helpers.rb
@@ -29,7 +29,7 @@ def random_urn_uuid
   "urn:uuid:#{SecureRandom.uuid}"
 end
 
-def build_bom(gems)
+def build_bom(gems, format)
   builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
     attributes = { 'xmlns' => 'http://cyclonedx.org/schema/bom/1.1', 'version' => '1', 'serialNumber' => random_urn_uuid }
     xml.bom(attributes) do
@@ -61,7 +61,16 @@ def build_bom(gems)
       end
     end
   end
-  builder.to_xml
+
+  xml = builder.to_xml
+
+  # Format verified to be either xml (default) or json in setup
+  if format == 'json'
+    JSON.pretty_generate(Hash.from_xml(xml))
+  else
+    xml
+  end
+
 end
 
 def get_gem(name, version)


### PR DESCRIPTION
## Addresses Issue [#12](https://github.com/CycloneDX/cyclonedx-ruby-gem/issues/12)

## Description of Change
- Added support for JSON bom output from existing xml format 
- Components support **type, name, version, description, purl, hash, license**
- Added option to specify bom output format with default being xml
- Update README reflecting new input options

<details>
  <summary>Example JSON Output</summary>
  
```
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.1",
  "serialNumber": "urn:uuid:dd6f65c3-9a54-4af1-81fb-69b8901fbfe6",
  "version": 1,
  "components": [
    {
      "type": "library",
      "name": "cyclonedx-ruby",
      "version": "1.1.0",
      "description": "CycloneDX software bill-of-material (SBoM) generation utility",
      "purl": "pkg:gem/cyclonedx-ruby@1.1.0",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "a6d2ee6824fbd881f7a66092ecbe152422fd068e822709e9fa2648656b006900"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "Apache-2.0"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "diff-lcs",
      "version": "1.5.0",
      "description": "Diff::LCS computes the difference between two Enumerable sequences using the McIlroy-Hunt longest common subsequence (LCS) algorithm",
      "purl": "pkg:gem/diff-lcs@1.5.0",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "49b934001c8c6aedb37ba19daec5c634da27b318a7a3c654ae979d6ba1929b67"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "domain_name",
      "version": "0.5.20190701",
      "description": "Domain Name manipulation library for Ruby",
      "purl": "pkg:gem/domain_name@0.5.20190701",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "000a600454cb4a344769b2f10b531765ea7bd3a304fe47ed12e5ca1eab969851"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "BSD-2-Clause"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "http-accept",
      "version": "1.7.0",
      "description": "Parse Accept and Accept-Language HTTP headers.",
      "purl": "pkg:gem/http-accept@1.7.0",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "c626860682bfbb3b46462f8c39cd470fd7b0584f61b3cc9df5b2e9eb9972a126"
        }
      ]
    },
    {
      "type": "library",
      "name": "http-cookie",
      "version": "1.0.4",
      "description": "A Ruby library to handle HTTP Cookies based on RFC 6265",
      "purl": "pkg:gem/http-cookie@1.0.4",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "89a64e1b9e3ed823b559b2030e0b62ad850d0d11325a0589145ebf93d80267a4"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "json",
      "version": "2.6.1",
      "description": "JSON Implementation for Ruby",
      "purl": "pkg:gem/json@2.6.1",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "8fdba4d7ba158cc901c155bd943460cb9b608ed919334df709d2da11085ac7d7"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "Ruby"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "mime-types",
      "version": "3.4.1",
      "description": "The mime-types library provides a library and registry for information about MIME content type definitions",
      "purl": "pkg:gem/mime-types@3.4.1",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "6bcf8b0e656b6ae9977bdc1351ef211d0383252d2f759a59ef4bcf254542fc46"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "mime-types-data",
      "version": "3.2022.0105",
      "description": "mime-types-data provides a registry for information about MIME media type definitions",
      "purl": "pkg:gem/mime-types-data@3.2022.0105",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "d8c401ba9ea8b648b7145b90081789ec714e91fd625d82c5040079c5ea696f00"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "mini_portile2",
      "version": "2.7.1",
      "description": "Simplistic port-like solution for developers",
      "purl": "pkg:gem/mini_portile2@2.7.1",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "dfdc965fec8c2ea4b1d0662cbd03cf23644aa4f42948feb7ea1aaa6b4c506f34"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "netrc",
      "version": "0.11.0",
      "description": "Library to read and write netrc files.",
      "purl": "pkg:gem/netrc@0.11.0",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "nokogiri",
      "version": "1.13.1",
      "description": "Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.",
      "purl": "pkg:gem/nokogiri@1.13.1",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "2138bb8e1bd5f11c2dc57a6a7ed93ddce35825dae7d25262658d89a222571fff"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "ostruct",
      "version": "0.5.3",
      "description": "Class to build custom data structures, similar to a Hash.",
      "purl": "pkg:gem/ostruct@0.5.3",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "44f839f1aff6f5778d30b57630eeb11b836ad373160631f69a6eac6125fb5c40"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "Ruby"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "racc",
      "version": "1.6.0",
      "description": "Racc is a LALR(1) parser generator",
      "purl": "pkg:gem/racc@1.6.0",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "d449a3c279026451b9fd5f34e829dc5f6e0ef6b9b472b7ff89fd3877fe8fe8cf"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "Ruby"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "rake",
      "version": "12.3.3",
      "description": "Rake is a Make-like program implemented in Ruby",
      "purl": "pkg:gem/rake@12.3.3",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "f7694adb4fe638da35452300cee6c545e9c377a0e3190018ac04d590b3c26ab3"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "rest-client",
      "version": "2.1.0",
      "description": "Simple HTTP and REST client for Ruby, inspired by microframework syntax for specifying actions.",
      "purl": "pkg:gem/rest-client@2.1.0",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "a35a3bb8d16ca39d110a946a2c805267f98ce07a0ae890e4512a45eadea47a6e"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "rspec",
      "version": "3.10.0",
      "description": "rspec-3.10.0",
      "purl": "pkg:gem/rspec@3.10.0",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "b870b43d49ae4a4e063b94976d2742b0854ec10458c425d569b5556ee5898ab7"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "rspec-core",
      "version": "3.10.1",
      "description": "rspec-core-3.10.1",
      "purl": "pkg:gem/rspec-core@3.10.1",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "ac9abdc9577a3a34e9e92815603da8343931055ab4fba1c2a49de6dd3b749673"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "rspec-expectations",
      "version": "3.10.2",
      "description": "rspec-expectations-3.10.2",
      "purl": "pkg:gem/rspec-expectations@3.10.2",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "fa9fdf7e7bf2e5e5b3143b2b18fea05e209406d96b92a9a722753426931432e3"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "rspec-mocks",
      "version": "3.10.2",
      "description": "rspec-mocks-3.10.2",
      "purl": "pkg:gem/rspec-mocks@3.10.2",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "93fc76e312c3d19cacc1cb2eb64bf82731de2e216295cf2b4d0ce31ba77923b4"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "rspec-support",
      "version": "3.10.3",
      "description": "rspec-support-3.10.3",
      "purl": "pkg:gem/rspec-support@3.10.3",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "65c88f8cbe579461f411097682e6402960eae327eef08e86ef581b8c609e4c5e"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "unf",
      "version": "0.1.4",
      "description": "A wrapper library to bring Unicode Normalization Form support to Ruby/JRuby",
      "purl": "pkg:gem/unf@0.1.4",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "49a5972ec0b3d091d3b0b2e00113f2f342b9b212f0db855eb30a629637f6d302"
        }
      ],
      "licenses": [
        {
          "license": {
            "name": "2-clause BSDL"
          }
        }
      ]
    },
    {
      "type": "library",
      "name": "unf_ext",
      "version": "0.0.8",
      "description": "Unicode Normalization Form support library for CRuby",
      "purl": "pkg:gem/unf_ext@0.0.8",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "bddafb9a2080767eabd9ac8568c7f8af8afc3c783d50688ad89921ec3e901e1a"
        }
      ],
      "licenses": [
        {
          "license": {
            "id": "MIT"
          }
        }
      ]
    }
  ]
}
```

</details>