### PR TITLE
Bump version to 1.2.0 and upgrade dependencies

### DIFF
--- a/cyclonedx-ruby.gemspec
+++ b/cyclonedx-ruby.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'cyclonedx-ruby'
-  spec.version     = '1.1.0'
-  spec.date        = '2019-07-12'
+  spec.version     = '1.2.0'
+  spec.date        = '2023-07-14'
   spec.summary     = 'CycloneDX software bill-of-material (SBoM) generation utility'
   spec.description = 'CycloneDX is a lightweight software bill-of-material (SBOM) specification designed for use in application security contexts and supply chain component analysis. This Gem generates CycloneDX BOMs from Ruby projects.'
   spec.authors     = ['Joseph Kobti', 'Steve Springett']
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/CycloneDX/cyclonedx-ruby-gem'
   spec.license     = 'Apache-2.0'
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
@@ -22,15 +22,15 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('json', '~> 2.2')
-  spec.add_dependency('nokogiri', '~> 1.8')
-  spec.add_dependency('ostruct', '~> 0.1')
+  spec.add_dependency('json', '~> 2.6')
+  spec.add_dependency('nokogiri', '~> 1.15')
+  spec.add_dependency('ostruct', '~> 0.5.5')
   spec.add_dependency('rest-client', '~> 2.0')
   spec.add_dependency('activesupport', '~> 7.0')
-  spec.add_development_dependency 'rake', '~> 12'
-  spec.add_development_dependency 'rspec', '~> 3.7'
+  spec.add_development_dependency 'rake', '~> 13'
+  spec.add_development_dependency 'rspec', '~> 3.12'
   spec.add_development_dependency 'cucumber', '~> 8.0'
   spec.add_development_dependency 'aruba', '~> 2.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
-  spec.add_development_dependency 'rubocop',  '~> 1.48'
+  spec.add_development_dependency 'rubocop',  '~> 1.54'
 end


### PR DESCRIPTION
`cyclonedx-ruby` has a flag, `-f` or `--format`, that allows for json output in addition to xml. This functionality has been added to the code but has not been released. By bumping the version number, a new gem can be cut that has the enhanced output functionality.

Additionally, the gem's dependencies were updated to newer versions. Some of these upgrades, such as the ones for `json` and `nokogiri`, contain bug fixes, but all are compatible with Ruby 2.7.0 and greater, which is the version of Ruby pegged in the `cyclonedx-ruby.gemspec` file.