### PR TITLE
chore: fix license text

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright OWASP Foundation
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Apache 2.0 license text is not a tenplate but a complete text.
the text must not be altered, not even the appendix.

so i copy-pastets in the original text from https://www.apache.org/licenses/LICENSE-2.0.txt