### PR TITLE
ci: run rubocop

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  RUBY_VERSION_DEFAULT: '4.0'  # see https://www.ruby-lang.org/en/downloads/releases/
   COVERAGE_DIR: coverage
   TESTS_COVERAGE_ARTIFACT: coverage
 
@@ -86,3 +87,28 @@ jobs:
         with:
           project-token: ${{ env.CODACY_PROJECT_TOKEN }}
           coverage-reports: '${{ env.TESTS_COVERAGE_ARTIFACT }}_*/coverage.xml'
+  rubocop:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        # see https://github.com/ruby/setup-ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        with:
+          ruby-version: ${{ env.RUBY_VERSION_DEFAULT }}
+          # intentionally disabled to avoid cache poisoning risks flagged by zizmor
+          bundler-cache: false
+      - name: Install Dependencies
+        run: bundle install
+      - name: Run RuboCop
+        # see https://rubocop.org/
+        run: >
+          bundle exec rubocop
+          --format simple
+          --format github


### PR DESCRIPTION


### Description

run RuboCop in CI -- fixing things is out of scope 

Resolves or fixes issue: #68

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/CONTRIBUTING.md) guidelines
