### PR TITLE
build: semi-automated release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v*.*.*"]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
       - name: Create GitHub Release
         run: |
-          gh release create "${{ github.ref_name }}" \
+          gh release create "$GITHUB_REF_NAME" \
             --verify-tag \
             --generate-notes
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           ruby-version: ruby
           bundler-cache: false
       - name: "Push gem to RubyGems"
+        # see https://github.com/rubygems/release-gem
         uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
 
   github_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - name: Set up Ruby
         # see https://github.com/ruby/setup-ruby
-        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '3.3.9'
           bundler-cache: false
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - name: Set up Ruby
         # see https://github.com/ruby/setup-ruby
-        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
           bundler-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   push:
     tags: ["v*.*.*"]
 
-permissions:
-  contents: read
+# see https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#modifying-the-permissions-for-the-github_token
+permissions: {}
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
     timeout-minutes: 10
     needs: rubygems_release
     environment: release
+    # Needed for `gh release create` because GitHub Releases require write access
+    # to repository contents, which is not granted by default with GITHUB_TOKEN.
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,13 @@ jobs:
       - name: "Push gem to RubyGems"
         # see https://github.com/rubygems/release-gem
         uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
+      - name: Upload gem artifact
+        # see https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: gem
+          path: pkg/*.gem
+          retention-days: 1
 
   github_release:
     name: GitHub Release
@@ -71,6 +78,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Download gem artifact
+        # see https://github.com/actions/download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gem
+          path: pkg
       - name: Create GitHub Release
         run: |
           declare -a FLAGS=("--verify-tag" "--generate-notes")
@@ -81,6 +94,6 @@ jobs:
           fi
 
           # Publish the release on GitHub with auto-generated release notes
-          gh release create "${FLAGS[@]}" -- "$GITHUB_REF_NAME"
+          gh release create "${FLAGS[@]}" -- "$GITHUB_REF_NAME" pkg/*.gem
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout Code
         # see https://github.com/actions/checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Checkout Code
         # see https://github.com/actions/checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Ruby
@@ -65,7 +65,7 @@ jobs:
     steps:
       - name: Checkout Code
         # see https://github.com/actions/checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,28 @@ jobs:
 
   rubygems_release:
     name: RubyGems Release
+    if: github.repository == 'CycloneDX/cyclonedx-ruby-gem'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: test
+    permissions:
+      contents: write
+      id-token: write
+    environment: release
     steps:
-      - run: echo "RubyGems publish (dummy step)"
+      - name: Checkout Code
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        # see https://github.com/ruby/setup-ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        with:
+          ruby-version: ruby
+          bundler-cache: false
+      - name: "Push gem to RubyGems"
+        uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
 
   github_release:
     name: GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        # see https://github.com/ruby/setup-ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        with:
+          ruby-version: '3.3.9'
+          bundler-cache: false
+      - name: Install Dependencies
+        run: bundle install
+      - name: Run the default task
+        run: bundle exec rake
+
+  rubygems_release:
+    name: RubyGems Release
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - run: echo "RubyGems publish (dummy step)"
+
+  github_release:
+    name: GitHub Release
+    if: github.repository == 'CycloneDX/cyclonedx-ruby-gem'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: rubygems_release
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Create GitHub Release
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --verify-tag \
+            --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         # see https://github.com/ruby/setup-ruby
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
-          ruby-version: ruby
+          ruby-version: '3.4' # Stable environment to package the gem for the supported ruby versions
           bundler-cache: false
       - name: "Push gem to RubyGems"
         # see https://github.com/rubygems/release-gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
     timeout-minutes: 10
     needs: test
     permissions:
-      contents: write
-      id-token: write
+      contents: write # Required for `rake release` to perform git synchronization.
+      id-token: write # Required for Trusted Publishing authentication.
     environment: release
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,14 @@ jobs:
           persist-credentials: false
       - name: Create GitHub Release
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --verify-tag \
-            --generate-notes
+          declare -a FLAGS=("--verify-tag" "--generate-notes")
+
+          # Determine release type from tag suffix
+          if [[ "$GITHUB_REF_NAME" =~ -(alpha|beta|rc|pre)[0-9.]*$ ]]; then
+            FLAGS+=("--prerelease")
+          fi
+
+          # Publish the release on GitHub with auto-generated release notes
+          gh release create "${FLAGS[@]}" -- "$GITHUB_REF_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           ruby-version: '3.4' # Stable environment to package the gem for the supported ruby versions
           bundler-cache: false
-      - name: "Push gem to RubyGems"
+      - name: Push gem to RubyGems
         # see https://github.com/rubygems/release-gem
         uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
       - name: Upload gem artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           declare -a FLAGS=("--verify-tag" "--generate-notes")
 
           # Determine release type from tag suffix
-          if [[ "$GITHUB_REF_NAME" =~ -(alpha|beta|rc|pre)[0-9.]*$ ]]; then
+          if [[ "$GITHUB_REF_NAME" =~ [-\.](alpha|beta|rc|pre)[0-9.]*$ ]]; then
             FLAGS+=("--prerelease")
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - name: Set up Ruby
         # see https://github.com/ruby/setup-ruby
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           ruby-version: '3.3.9'
           bundler-cache: false
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - name: Set up Ruby
         # see https://github.com/ruby/setup-ruby
-        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           ruby-version: '3.4' # Stable environment to package the gem for the supported ruby versions
           bundler-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         # see https://github.com/ruby/setup-ruby
         uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
-          ruby-version: '3.4' # Stable environment to package the gem for the supported ruby versions
+          ruby-version: '3.4.10' # Stable environment to package the gem for the supported ruby versions
           bundler-cache: false
       - name: Push gem to RubyGems
         # see https://github.com/rubygems/release-gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Please file a bug if you notice a violation of semantic versioning.
 
 ### Added
 
+- Semi-automated CI release workflow triggered by version tags (`vMAJOR.MINOR.PATCH` with optional pre-release suffixes) (#46)
+- RubyGems publishing via `rubygems_release` using trusted publishing
+- Automated GitHub Releases with generated release notes, including support for pre-releases
 - `CONTRIBUTING.md` file to help people find their way to contributing
 - `CHANGELOG.md` file to document notable changes in keep-a-changelog format
 - `Cyclonedx::BomHelpers` module to house helper methods, replacing global methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@
 
 All notable changes to this project after v1.1.0 will be documented in this file.
 
-The format is based on [Keep a Changelog][📗keep-changelog],
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
-and [yes][📌major-versions-not-sacred], platform and engine support are part of the [public API][📌semver-breaking].
-Please file a bug if you notice a violation of semantic versioning.
+The format is based on [Keep a Changelog][📗keep-changelog].
+
+This project follows [Semantic Versioning (SemVer)][📌semver] with one intentional convention: prerelease versions use dotted prerelease identifiers instead of the standard hyphenated form. For example:
+
+- `1.2.0.pre.1` (used by this project)
+- `1.2.0-pre.1` (standard SemVer equivalent)
+
+Aside from this prerelease notation, platform and engine support are part of the [public API][📌semver-breaking]. See [Major Version Numbers Are Not Sacred][📌major-versions-not-sacred] for additional context.
+
+
+Please file a bug if you notice a violation of this project's versioning policy.
 
 [📌semver]: https://semver.org/spec/v2.0.0.html
 [📌semver-img]: https://img.shields.io/badge/semver-2.0.0-FFDD67.svg?style=flat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Made with [contributors-img][🖐contrib-rocks].
 
 > [!WARNING]
 > The gem version and git tag MUST match. A mismatch may cause `rake release` (invoked by `rubygems/release-gem`) to create and push a tag for the gem version, which could produce unexpected results.
-5. Monitor the release workflow and verify that the release completes succesfully.
+5. Monitor the release workflow and verify that the release completes successfully.
 
 [📜src-gh]: https://github.com/CycloneDX/cyclonedx-ruby-gem
 [🧪build]: https://github.com/CycloneDX/cyclonedx-ruby-gem/actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,8 @@ Made with [contributors-img][🖐contrib-rocks].
     - NOTE: Remember to [check the build][🧪build].
 4. Create a git tag for the gem version. Prefix the tag with 'v'. For example, if the current [gem version](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/lib/cyclonedx/ruby/version.rb) is 1.2.0, the tag should be 'v1.2.0'. Pre-releases are supported. See the [release workflow](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/.github/workflows/release.yml) for more details. Push the tag to the repository to trigger the release workflow.
 
-   > [!WARNING]
-   > The gem version and git tag MUST match. A mismatch may cause `rake release` (invoked by `rubygems/release-gem`) to create and push a tag for the gem version, which could produce unexpected results.
+> [!WARNING]
+> The gem version and git tag MUST match. A mismatch may cause `rake release` (invoked by `rubygems/release-gem`) to create and push a tag for the gem version, which could produce unexpected results.
 5. Monitor the release workflow and verify that the release completes succesfully.
 
 [📜src-gh]: https://github.com/CycloneDX/cyclonedx-ruby-gem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,36 +88,20 @@ Made with [contributors-img][🖐contrib-rocks].
 
 ### To release a new version:
 
-#### Automated process
+#### Semi-automated process
 
-Coming Soon!
-
-#### Manual process
-
-1. Run `bin/setup && bin/rake` as a "test, coverage, & linting" sanity check
-2. Update the version number in `version.rb`, and ensure `CHANGELOG.md` reflects changes
-3. Run `bin/setup && bin/rake` again as a secondary check, and to update `Gemfile.lock`
-4. Run `git commit -am "🔖 Prepare release v<VERSION>"` to commit the changes
-5. Run `git push` to trigger the final CI pipeline before release, and merge PRs
+1. Update the version number in `version.rb`, and ensure `CHANGELOG.md` reflects the changes.
+2. Commit the changes:
+   ```sh
+   git commit -am "🔖 Prepare release v<VERSION>"
+   ```
+3. Push the changes to trigger the final CI pipeline before the release.
     - NOTE: Remember to [check the build][🧪build].
-6. Run `export GIT_TRUNK_BRANCH_NAME="$(git remote show origin | grep 'HEAD branch' | cut -d ' ' -f5)" && echo $GIT_TRUNK_BRANCH_NAME`
-7. Run `git checkout $GIT_TRUNK_BRANCH_NAME`
-8. Run `git pull origin $GIT_TRUNK_BRANCH_NAME` to ensure latest trunk code
-9. Optional for older Bundler (< 2.7.0): Set `SOURCE_DATE_EPOCH` so `rake build` and `rake release` use the same timestamp and generate the same checksums
-    - If your Bundler is >= 2.7.0, you can skip this; builds are reproducible by default.
-    - Run `export SOURCE_DATE_EPOCH=$EPOCHSECONDS && echo $SOURCE_DATE_EPOCH`
-    - If the echo above has no output, then it didn't work.
-    - Note: `zsh/datetime` module is needed, if running `zsh`.
-    - In older versions of `bash` you can use `date +%s` instead, i.e. `export SOURCE_DATE_EPOCH=$(date +%s) && echo $SOURCE_DATE_EPOCH`
-10. Run `bundle exec rake build`
-11. Run `bundle exec rake release` which will create a git tag for the version,
-    push git commits and tags, and push the `.gem` file to the gem host configured in the gemspec.
-12. Run `bin/gem_checksums` (more context [1][🔒️rubygems-checksums-pr], [2][🔒️rubygems-guides-pr])
-    to create SHA-256 and SHA-512 checksums. This functionality is provided by the `stone_checksums`
-    [gem][💎stone_checksums].
-    - The script automatically commits but does not push the checksums
-13. Sanity check the SHA256, comparing with the output from the `bin/gem_checksums` command:
-    - `sha256sum pkg/<gem name>-<version>.gem`
+4. Create a git tag for the gem version. Prefix the tag with 'v'. For example, if the current [gem version](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/lib/cyclonedx/ruby/version.rb) is 1.2.0, the tag should be 'v1.2.0'. Pre-releases are supported. See the [release workflow](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/.github/workflows/release.yml) for more details. Push the tag to the repository to trigger the release workflow.
+
+   > [!WARNING]
+   > The gem version and git tag MUST match. A mismatch may cause `rake release` (invoked by `rubygems/release-gem`) to create and push a tag for the gem version, which could produce unexpected results.
+5. Monitor the release workflow and verify that the release completes succesfully.
 
 [📜src-gh]: https://github.com/CycloneDX/cyclonedx-ruby-gem
 [🧪build]: https://github.com/CycloneDX/cyclonedx-ruby-gem/actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Made with [contributors-img][🖐contrib-rocks].
    ```
 3. Push the changes to trigger the final CI pipeline before the release.
     - NOTE: Remember to [check the build][🧪build].
-4. Create a git tag for the gem version. Prefix the tag with 'v'. For example, if the current [gem version](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/lib/cyclonedx/ruby/version.rb) is 1.2.0, the tag should be 'v1.2.0'. Pre-releases are supported. See the [release workflow](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/.github/workflows/release.yml) for more details. Push the tag to the repository to trigger the release workflow.
+4. Create a git tag for the gem version. Prefix the tag with 'v'. For example, if the current [gem version](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/lib/cyclonedx/ruby/version.rb) is 1.2.0, the tag should be 'v1.2.0'. Pre-releases are supported. See [CHANGELOG.md](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/CHANGELOG.md) and the [release workflow](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/.github/workflows/release.yml) for more details. Push the tag to the repository to trigger the release workflow.
 
 > [!WARNING]
 > The gem version and git tag MUST match. A mismatch may cause `rake release` (invoked by `rubygems/release-gem`) to create and push a tag for the gem version, which could produce unexpected results.


### PR DESCRIPTION
<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

You can expedite processing of your PR by using this template to provide context
and additional information. Before actually opening a PR please make sure that it
does NOT fall into any of the following categories

🚫 Spam PRs (accidental or intentional) - these will result in a 30-days or even
∞ ban from interacting with the project depending on reoccurrence and severity.

🚫 Lazy typo fixing PRs - if you fix a typo in a file, your PR will only be merged
if all other typos in the same file are also fixed with the same PR

🚫 If you fail to provide any _Description_ below, your PR will be considered spam.
If you do not check the _Affirmation_ box below, your PR will not be merged.

🚫 If you do not check one of the _AI Tool Disclosure_ boxes below, your PR will
not be merged. If you used AI tools to assist you in writing code, but fail to
provide the required disclosure, your PR will not be merged.

🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->

### Description

<!-- ✍️-->
Add a release workflow for RubyGems and GitHub Releases triggered by version tags (`v*.*.*`).

This PR resolves issue: #46.

The workflow consists of three jobs:

1. **Test**: runs the test suite using Ruby 3.3.
2. **RubyGems Release**: publishes the gem to RubyGems using trusted publishing.
3. **GitHub Release**: creates a GitHub Release with generated release notes.

~~The GitHub Release does not include a built gem package and is intended only for release metadata and assets.~~

## Future Improvements

To keep this change focused, a few related enhancements are left for follow-up work:

* Verify that the gem version matches the release tag before publishing.
* Ensure the tagged commit is reachable from a protected release branch (e.g. main) before publishing to reduce the risk of releasing from an unreviewed commit outside the normal development workflow.
* Generate and publish SHA hashes for release assets.
* ~~Document the release process (e.g.  updating the gem version, creating and publishing a release tag, and publishing a release).~~ Updated `CONTRIBUTING.md` in commit https://github.com/CycloneDX/cyclonedx-ruby-gem/commit/5545c7ca1dc2aec35b92880e215cef7b8954171f.

~~Release documentation will be added in a follow-up PR.~~

## Testing

**The workflow has been validated to the extent possible, but I was unable to perform an end-to-end test for the RubyGems publishing step because trusted publishing requires maintainer-controlled RubyGems and repository configuration.**

A maintainer will need to:

* Create and configure a `release` environment if one does not already exist.
* Configure RubyGems trusted publishing for the repository/environment.
* Perform a test release to verify that the trusted publishing configuration is set up correctly.

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-ruby-gem/blob/master/CONTRIBUTING.md) guidelines
